### PR TITLE
Try and use a SciToken before using X509

### DIFF
--- a/dqsegdb2/http.py
+++ b/dqsegdb2/http.py
@@ -29,8 +29,8 @@ def request(url, **urlopen_kw):
     is not given, a SciToken will be looked for in the
     following search order:
 
-    1. The contents of the file `${_CONDOR_CREDS}/scitokens.use`
-    2. The contents of the file pointed to by the environment variable `${SCITOKENS_FILE}`
+    1. A file `${_CONDOR_CREDS}/scitokens.use`
+    2. A file set by environment variable `${SCITOKENS_FILE}`
     3. The contents of the environment variable `${SCITOKENS}`
 
     If not SciToken can be found, an X509 credentials will be automatically

--- a/dqsegdb2/http.py
+++ b/dqsegdb2/http.py
@@ -73,7 +73,7 @@ def request(url, **urlopen_kw):
                             tok = scitokens.SciToken.deserialize(token_data,
                                                                  audience=aud)
                             break
-                    except InvalidTokenFormat, InvalidAudienceError:
+                    except (InvalidTokenFormat, InvalidAudienceError):
                         # ignore files that do not contain tokens
                         # or that are for a different audience
                         pass

--- a/dqsegdb2/http.py
+++ b/dqsegdb2/http.py
@@ -20,6 +20,8 @@
 
 import os
 import json
+import scitokens
+from scitokens.utils.errors import InvalidTokenFormat, InvalidAudienceError
 from urllib.request import urlopen
 from urllib.parse import urlparse
 

--- a/dqsegdb2/http.py
+++ b/dqsegdb2/http.py
@@ -18,17 +18,23 @@
 """HTTP interactions with DQSEGDB
 """
 
+import os
 import json
 from urllib.request import urlopen
 from urllib.parse import urlparse
 
-
 def request(url, **urlopen_kw):
     """Request data from a URL
+    If the URL uses HTTPS and the `context` keyword
+    is not given, a SciToken will be looked for in the
+    following search order:
 
-    If the URL uses HTTPS and the ``context`` keyword
-    is not given, X509 credentials will be automatically loaded
-    using :func:`gwdatafind.utils.find_credential`.
+    1. The contents of the file `${_CONDOR_CREDS}/scitokens.use`
+    2. The contents of the file pointed to by the environment variable `${SCITOKENS_FILE}`
+    3. The contents of the environment variable `${SCITOKENS}`
+
+    If not SciToken can be found, an X509 credentials will be automatically
+    loaded using :func:`gwdatafind.utils.find_credential`.
 
     Parameters
     ----------
@@ -45,10 +51,29 @@ def request(url, **urlopen_kw):
     """
     if urlparse(url).scheme == 'https' and 'context' not in urlopen_kw:
         from ssl import create_default_context
-        from gwdatafind.utils import find_credential
         urlopen_kw['context'] = context = create_default_context()
-        context.load_cert_chain(*find_credential())
-    return urlopen(url, **urlopen_kw)
+        req = Request(url)
+
+        if os.environ.get('_CONDOR_CREDS'):
+          scitokens_path = os.path.join(os.environ['_CONDOR_CREDS'],'scitokens.use')
+        elif os.environ.get('SCITOKENS_FILE'):
+          scitokens_path = 'scitokens.use'
+        else:
+          scitokens_path = ''
+
+        if os.path.isfile(scitokens_path):
+          with open(scitokens_path) as f: token_data = f.read()
+        elif os.environ.get('SCITOKEN'):
+          token_data = os.environ['SCITOKEN']
+        else:
+          token_data = None
+          from gwdatafind.utils import find_credential
+          context.load_cert_chain(*find_credential())
+
+        if token_data:
+          req.add_header("Authorization", "Bearer " + token_data.rstrip())
+
+    return urlopen(req, **urlopen_kw)
 
 
 def request_json(url, **kwargs):

--- a/dqsegdb2/http.py
+++ b/dqsegdb2/http.py
@@ -72,6 +72,8 @@ def request(url, **urlopen_kw):
 
         if token_data:
           req.add_header("Authorization", "Bearer " + token_data.rstrip())
+    else:
+        req = Request(url)
 
     return urlopen(req, **urlopen_kw)
 

--- a/dqsegdb2/http.py
+++ b/dqsegdb2/http.py
@@ -21,7 +21,9 @@
 import os
 import json
 import scitokens
-from scitokens.utils.errors import InvalidTokenFormat, InvalidAudienceError
+from scitokens.utils.errors import InvalidTokenFormat
+from jwt.exceptions import InvalidAudienceError
+from urllib.request import Request
 from urllib.request import urlopen
 from urllib.parse import urlparse
 

--- a/dqsegdb2/http.py
+++ b/dqsegdb2/http.py
@@ -55,23 +55,25 @@ def request(url, **urlopen_kw):
         req = Request(url)
 
         if os.environ.get('_CONDOR_CREDS'):
-          scitokens_path = os.path.join(os.environ['_CONDOR_CREDS'],'scitokens.use')
+            scitokens_path = os.path.join(os.environ['_CONDOR_CREDS'],
+                                          'scitokens.use')
         elif os.environ.get('SCITOKENS_FILE'):
-          scitokens_path = 'scitokens.use'
+            scitokens_path = 'scitokens.use'
         else:
-          scitokens_path = ''
+            scitokens_path = ''
 
         if os.path.isfile(scitokens_path):
-          with open(scitokens_path) as f: token_data = f.read()
+            with open(scitokens_path) as f:
+                token_data = f.read()
         elif os.environ.get('SCITOKEN'):
-          token_data = os.environ['SCITOKEN']
+            token_data = os.environ['SCITOKEN']
         else:
-          token_data = None
-          from gwdatafind.utils import find_credential
-          context.load_cert_chain(*find_credential())
+            token_data = None
+            from gwdatafind.utils import find_credential
+            context.load_cert_chain(*find_credential())
 
         if token_data:
-          req.add_header("Authorization", "Bearer " + token_data.rstrip())
+            req.add_header("Authorization", "Bearer " + token_data.rstrip())
     else:
         req = Request(url)
 

--- a/dqsegdb2/http.py
+++ b/dqsegdb2/http.py
@@ -52,10 +52,10 @@ def request(url, **urlopen_kw):
     reponse : `http.client.HTTPResponse`
         the reponse from the URL
     """
+    req = Request(url)
     if urlparse(url).scheme == 'https' and 'context' not in urlopen_kw:
         from ssl import create_default_context
         urlopen_kw['context'] = context = create_default_context()
-        req = Request(url)
         aud = urlparse(url).hostname
         token_data = None
         tok = None
@@ -101,8 +101,6 @@ def request(url, **urlopen_kw):
         else:
             from gwdatafind.utils import find_credential
             context.load_cert_chain(*find_credential())
-    else:
-        req = Request(url)
 
     return urlopen(req, **urlopen_kw)
 

--- a/dqsegdb2/tests/test_http.py
+++ b/dqsegdb2/tests/test_http.py
@@ -26,7 +26,7 @@ from .. import http
 
 @mock.patch('dqsegdb2.http.urlopen')
 def test_request_http(urlopen):
-    http.request('test', a=1, b=2)
+    http.request('http://test', a=1, b=2)
     urlopen.assert_called_once_with(mock.ANY, a=1, b=2)
 
 

--- a/dqsegdb2/tests/test_http.py
+++ b/dqsegdb2/tests/test_http.py
@@ -31,13 +31,14 @@ def test_request_http(urlopen):
 
 
 @mock.patch('ssl.create_default_context')
+@mock.patch('gwdatafind.utils.find_scitoken')
 @mock.patch('gwdatafind.utils.find_credential')
 @mock.patch('dqsegdb2.http.urlopen')
-def test_request_https(urlopen, find, create):
-    print(create, find, urlopen)
+def test_request_https(urlopen, findc, finds, create):
     create.return_value = context = mock.MagicMock()
     http.request('https://test', a=1)
-    find.assert_called_once_with()
+    finds.assert_called_once_with(aud='test', scope='read:/DQSegDB')
+    findc.assert_called_once_with()
     urlopen.assert_called_once_with(mock.ANY, context=context, a=1)
 
 

--- a/dqsegdb2/tests/test_http.py
+++ b/dqsegdb2/tests/test_http.py
@@ -27,7 +27,7 @@ from .. import http
 @mock.patch('dqsegdb2.http.urlopen')
 def test_request_http(urlopen):
     http.request('test', a=1, b=2)
-    urlopen.assert_called_once_with('test', a=1, b=2)
+    urlopen.assert_called_once_with(mock.ANY, a=1, b=2)
 
 
 @mock.patch('ssl.create_default_context')
@@ -38,7 +38,7 @@ def test_request_https(urlopen, find, create):
     create.return_value = context = mock.MagicMock()
     http.request('https://test', a=1)
     find.assert_called_once_with()
-    urlopen.assert_called_once_with('https://test', context=context, a=1)
+    urlopen.assert_called_once_with(mock.ANY, context=context, a=1)
 
 
 @mock.patch('dqsegdb2.http.urlopen')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ gwdatafind
 ligo-segments
 pytest
 pytest-cov
-scitokens
+scitokens>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ gwdatafind
 ligo-segments
 pytest
 pytest-cov
+scitokens

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ setup_requires =
 install_requires =
 	gwdatafind
 	ligo-segments
+        scitokens >=1.4.0
 tests_require =
 	pytest
 	pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ def parse_version(path):
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
-
 setup(
     version=parse_version(os.path.join("dqsegdb2", "__init__.py")),
 )

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ def parse_version(path):
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
+
 setup(
     version=parse_version(os.path.join("dqsegdb2", "__init__.py")),
 )


### PR DESCRIPTION
This pull request add the ability to use a SciToken before trying to use X509 certificates when talking to the segment database. The SciToken is looked for in:

1. The contents of the file `${_CONDOR_CREDS}/scitokens.use`
2. The contents of the file pointed to by the environment variable `${SCITOKENS_FILE}`
3. The contents of the environment variable `${SCITOKENS}`

If a SciToken is not found, X509 authentication is used.