### PR TITLE
Use --tee option for flake8

### DIFF
--- a/.azure-pipelines/lint.yml
+++ b/.azure-pipelines/lint.yml
@@ -6,11 +6,8 @@ jobs:
   - task: UsePythonVersion@0
   - script: python3 -m pip install --upgrade flake8 flake8-junit-report
     displayName: "Install flake8"
-  - script: python3 -m flake8 --output-file flake8.out
+  - script: python3 -m flake8 --tee --output-file flake8.out
     displayName: "Run linter"
-  - script: cat flake8.out
-    displayName: "Print lint results"
-    condition: succeededOrFailed()
   - script: python3 -m junit_conversor flake8.out flake8.xml
     displayName: "Convert flake8 output to JUnit"
     condition: succeededOrFailed()


### PR DESCRIPTION
This PR modifies the execution of `flake8` in CI to better improve the ability for developers to find flake8 issues.